### PR TITLE
Fix readme and allow other platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 AWS CLI Tools
 =========
 
-This role downloads and installs the AWS CLI Tools via Python pip.
+This role installs the AWS CLI Tools using Python pip.
 
 [![Build Status](https://travis-ci.org/Rheinwerk/ansible-role-awscli.svg?branch=master)](https://travis-ci.org/Rheinwerk/ansible-role-awscli)
 
 Requirements
 ------------
 
-None.
+Python and pip must be installed.
 
 Role Variables
 --------------
 
-Please see `defaults/main.yml` for details.
+No variables.
 
 Dependencies
 ------------
@@ -23,16 +23,9 @@ None.
 Example Playbook
 ----------------
 
-The general contract of this role is to take the variables map `_awscli` from `defaults/main.yml` as a template for your configuration and pass that configuration as a parameter to this role.
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
     - hosts: servers
-      var:
-        AWSCLI:
-          ...
       roles:
-         - { role: awscli, tags: [ 'awscli' ], _awscli: "{{ AWSCLI }}" }
+         - { role: awscli }
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: awscli }
+         - { role: awscli, tags: [ 'awscli' ] }
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,11 +3,28 @@ galaxy_info:
   description: Installs Amazon AWS CLI
   company: Rheinwerk
   license: license (GPLv3)
-  min_ansible_version: 2.2
+  min_ansible_version: 2.0
   platforms:
   - name: Ubuntu
     versions:
+    - lucid
+    - maverick
+    - natty
+    - oneiric
+    - precise
+    - quantal
+    - raring
+    - saucy
     - trusty
+    - utopic
+    - vivid
+    - wily
+    - yakkety
+  - name: EL
+    versions:
+    - 5
+    - 6
+    - 7
   galaxy_tags:
     - amazon
     - aws


### PR DESCRIPTION
Update the readme to remove boilerplate text and correct the description and requirements.

Add other platforms to the list so that it can be used with all versions of Ubuntu and EL. All platforms should support this, since pip can be installed anywhere.